### PR TITLE
Log system's hardware as described in the system BIOS according to th…

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -39,6 +39,7 @@ typedef enum nwipe_log_t_
 
 void nwipe_log( nwipe_log_t level, const char* format, ... );
 void nwipe_perror( int nwipe_errno, const char* f, const char* s );
+int nwipe_log_sysinfo();
 
 /* Global array to hold log values to print when logging to STDOUT */
 //extern char **log_lines;

--- a/src/nwipe.c
+++ b/src/nwipe.c
@@ -107,6 +107,9 @@ int main( int argc, char** argv )
                 }
 
         }
+        
+        /* Log the System information */
+        nwipe_log_sysinfo();
 
 
         /* The array of pointers to contexts that will actually be wiped. */


### PR DESCRIPTION
…e SMBIOS/DMI standard.

Uses dmidecode with search keywords arguments. dmidecode -s to see available keywords.